### PR TITLE
Add body_format parameter to uri tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,7 @@
     user: admin
     password: "{{ grafana_admin_password }}"
     body: "{{ grafana_data_source | to_json }}"
+    body_format: json
     force_basic_auth: yes
   tags: datasource
   register: result
@@ -61,6 +62,7 @@
     user: admin
     password: "{{ grafana_admin_password }}"
     body: "{{ lookup('file',grafana_custom_dashboard) }}"
+    body_format: json
     force_basic_auth: yes
   tags: dashboard
   register: result


### PR DESCRIPTION
This is needed to prevent the tasks from failing.
