### PR TITLE
Multiple dashboard files and packagecloud repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ grafana_admin_password: "password"
 grafana_secret_key: "18Z98oGhk95Oo72OmuG484eBP4g2774c"
 grafana_session_provider: "memory"
 grafana_sessions_provider_config: ""
-grafana_custom_dashboard: false
+grafana_custom_dashboars: []
 
 # Data Source
 grafana_data_source: {

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ ansible-galaxy install jmartin.grafana
 ---
 # Packages
 grafana_packages:
-  - "https://grafanarel.s3.amazonaws.com/builds/grafana-2.5.0-1.x86_64.rpm"
+  - grafana
   - git
 
 # Server Configuration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 grafana_packages:
-  - "https://s3.amazonaws.com/ansible-training-resources/grafana/grafana-2.6.0-1.x86_64.rpm"
+  - "grafana"
   - "python-httplib2"
 
 grafana_ip: "0.0.0.0"
@@ -9,11 +9,13 @@ grafana_admin_password: "password"
 grafana_secret_key: "18Z98oGhk95Oo72OmuG484eBP4g2774c"
 grafana_session_provider: "memory"
 grafana_sessions_provider_config: ""
-grafana_custom_dashboard: false
+grafana_custom_dashboards: []
 
 # Plugins
 grafana_zabbix_plugin: false
 grafana_zabbix_version: "master"
+
+grafana_install_plugins: []
 
 # Google Auth
 grafana_auth_google: false
@@ -21,4 +23,3 @@ grafana_auth_google_allow_sign_up: "false"
 grafana_auth_google_client_id: "some_client_id"
 grafana_auth_google_client_secret: "some_client_secret"
 grafana_auth_google_allowed_domains: "petalmd.com"
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,26 +1,42 @@
 ---
+- name: Add Grafana repository
+  yum_repository:
+    name: grafana
+    description: Grafana Repository
+    baseurl: https://packagecloud.io/grafana/stable/el/7/$basearch
+    gpgcheck: yes
+    gpgkey:
+      - "https://packagecloud.io/gpg.key"
+      - "https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana"
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+
 - name: Install Grafana
-  yum: 
-    name: "{{item}}" 
+  yum:
+    name: "{{item}}"
     state: installed
   with_items: "{{grafana_packages}}"
   tags: package
 
 - name: Configure Grafana
-  template: 
+  template:
     src: grafana.ini.j2
     dest: /etc/grafana/grafana.ini
   notify: restart grafana
 
 - name: Install Grafana service
-  service: 
-    name: grafana-server 
+  service:
+    name: grafana-server
     state: started
     enabled: yes
 
 - name: wait for grafana port
   wait_for:
     port: "{{ grafana_port }}"
+
+- name: Install plugins
+  command: "grafana-cli plugins install {{ item }}"
+  with_items: "{{ grafana_install_plugins }}"
+  notify: restart grafana
 
 - name: get datasources
   uri:
@@ -61,11 +77,11 @@
     method: POST
     user: admin
     password: "{{ grafana_admin_password }}"
-    body: "{{ lookup('file',grafana_custom_dashboard) }}"
+    body: "{{ lookup('file',item) }}"
     body_format: json
     force_basic_auth: yes
   tags: dashboard
   register: result
   changed_when: result.status == 200
   failed_when: result.status != 200 and result.status != 412
-  when: grafana_custom_dashboard
+  with_items: "{{ grafana_custom_dashboards }}"


### PR DESCRIPTION
Added support for uploading default dashboards in multiple files, in order to be able to organize dashboards more clearly.

Instead of a boolean value to enable uploading a default dashboard, I'm using a variable called `grafana_custom_dashboards` which contains an empty list by default. When filenames are added to this list, all of them will be uploaded to the Grafana instance via an API call.

In addition, I've added the Grafana packagecloud repository (<https://packagecloud.io/grafana/stable>) so Grafana can be installed the normal way via yum.